### PR TITLE
Moving to Customized Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ We hope you enjoy the recipes we have here and please don't hesitate to contribu
 
 * Breakfast
 * Snack
+* Appetizer
 * Soup
-* Pasta
 * Casserole
+* Pasta
 * Meat
 * Seafood
+* Side
 * Dessert
 * Miscellaneous
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/bernardopacini/ReadTheRecipeTheme

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,7 +13,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-import sphinx_ReadTheRecipe_theme
+import sphinxReadTheRecipeTheme
 
 
 # -- Project information -----------------------------------------------------
@@ -44,8 +44,8 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_ReadTheRecipe_theme"
-html_theme_path = [sphinx_ReadTheRecipe_theme.get_html_theme_path()]
+html_theme = "sphinxReadTheRecipeTheme"
+html_theme_path = [sphinxReadTheRecipeTheme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,7 +13,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-import sphinx_readtherecipe_theme
+import sphinx_ReadTheRecipe_theme
 
 
 # -- Project information -----------------------------------------------------
@@ -44,8 +44,8 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_readtherecipe_theme"
-html_theme_path = [sphinx_readtherecipe_theme.get_html_theme_path()]
+html_theme = "sphinx_ReadTheRecipe_theme"
+html_theme_path = [sphinx_ReadTheRecipe_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,12 +13,13 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import sphinx_readtherecipe_theme
 
 
 # -- Project information -----------------------------------------------------
 
 project = "ReadTheRecipe"
-copyright = "2021"
+copyright = "2022"
 author = ""
 
 
@@ -27,7 +28,7 @@ author = ""
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx_rtd_theme"]
+# extensions = ["sphinx_rtd_theme"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -43,7 +44,8 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "sphinx_readtherecipe_theme"
+html_theme_path = [sphinx_readtherecipe_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,5 +1,5 @@
-ReadTheRecipe
-=============
+Welcome!
+========
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
ReadTheRecipe currently uses the generic docs theme that sort of screams "Python package documentation at work". So, I forked a different theme and made some changes that will be more fun for a recipe book.